### PR TITLE
fix capture group for end quote in strings

### DIFF
--- a/syntaxes/unison.tmLanguage.json
+++ b/syntaxes/unison.tmLanguage.json
@@ -160,7 +160,7 @@
         "1": {
           "name": "punctuation.definition.string.begin.unison"
         },
-        "2": {
+        "3": {
           "name": "punctuation.definition.string.end.unison"
         }
       }


### PR DESCRIPTION
Fixes the index for the left-quote capture group.
Before:

![CleanShot 2022-03-09 at 22 20 04@2x](https://user-images.githubusercontent.com/10248067/157601395-f05e3266-1737-4db1-8409-2a3012448a21.png)

After:

<img width="437" alt="CleanShot 2022-03-09 at 22 19 44@2x" src="https://user-images.githubusercontent.com/10248067/157601330-8de2432b-d843-4aa3-987b-84d119de4a04.png">
